### PR TITLE
Bugfix: Use flex instead of grid in main layout to center menu content

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -7,7 +7,7 @@ function RootLayout() {
 
   return (
     <GameContextProvider>
-      <main className={isMenu ? "grid flex-1 place-content-center" : ""}>
+      <main className={isMenu ? "flex-1 flex-col flex items-center justify-center" : ""}>
         <Outlet />
       </main>
     </GameContextProvider>


### PR DESCRIPTION
This PR replaces grid with flex to ensure the menu content remains centered and adapts dynamically to its size.