### PR TITLE
Refactor: use useGameContext and enforce lowercase player values in PickPlayer component

### DIFF
--- a/src/components/PickPlayer.tsx
+++ b/src/components/PickPlayer.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useGameContext } from "../contexts/GameContext";
 
 import IconX from "../assets/icons/icon-x.svg?react";
 import IconO from "../assets/icons/icon-o.svg?react";
 
 function PickPlayer() {
-  const [playerMark, setplayerMark] = useState("x");
+  const { playerMark, setPlayerMark } = useGameContext();
 
   return (
     <div className="bg-te-papa-green text-casper inset-shadow-lg inset-shadow-big-stone grid justify-items-center gap-4 rounded-lg px-6 pt-6 pb-7.5">
@@ -27,7 +27,7 @@ function PickPlayer() {
           className="sr-only"
           value="x"
           checked={playerMark === "x"}
-          onChange={() => setplayerMark("x")}
+          onChange={() => setPlayerMark("x")}
         />
         <label
           htmlFor="o"
@@ -44,7 +44,7 @@ function PickPlayer() {
           className="sr-only"
           value="o"
           checked={playerMark === "o"}
-          onChange={() => setplayerMark("o")}
+          onChange={() => setPlayerMark("o")}
         />
       </div>
       <span className="leading-[normal] font-medium tracking-wider uppercase">

--- a/src/components/PickPlayer.tsx
+++ b/src/components/PickPlayer.tsx
@@ -4,7 +4,7 @@ import IconX from "../assets/icons/icon-x.svg?react";
 import IconO from "../assets/icons/icon-o.svg?react";
 
 function PickPlayer() {
-  const [playerMark, setplayerMark] = useState("X");
+  const [playerMark, setplayerMark] = useState("x");
 
   return (
     <div className="bg-te-papa-green text-casper inset-shadow-lg inset-shadow-big-stone grid justify-items-center gap-4 rounded-lg px-6 pt-6 pb-7.5">
@@ -13,42 +13,42 @@ function PickPlayer() {
       </h2>
       <div className="bg-mirage mb-[calc(--spacing(0.5)-1px)] grid grid-cols-2 justify-self-stretch rounded-md px-2 py-[calc(--spacing(2)+1px)]">
         <label
-          htmlFor="X"
-          className={`${playerMark === "X" ? "bg-casper" : "hover:bg-casper/5"} grid cursor-pointer justify-items-center rounded-md p-[calc(--spacing(2.5)+1px)] duration-200`}
+          htmlFor="x"
+          className={`${playerMark === "x" ? "bg-casper" : "hover:bg-casper/5"} grid cursor-pointer justify-items-center rounded-md p-[calc(--spacing(2.5)+1px)] duration-200`}
         >
           <IconX
-            className={`${playerMark === "X" ? "fill-mirage" : "fill-casper"} duration-200`}
+            className={`${playerMark === "x" ? "fill-mirage" : "fill-casper"} duration-200`}
           />
         </label>
         <input
           type="radio"
           name="playerMark"
-          id="X"
+          id="x"
           className="sr-only"
-          value="X"
-          checked={playerMark === "X"}
-          onChange={() => setplayerMark("X")}
+          value="x"
+          checked={playerMark === "x"}
+          onChange={() => setplayerMark("x")}
         />
         <label
-          htmlFor="O"
-          className={`${playerMark === "O" ? "bg-casper" : "hover:bg-casper/5"} grid cursor-pointer justify-items-center rounded-md p-[calc(--spacing(2.5)+1px)] duration-200`}
+          htmlFor="o"
+          className={`${playerMark === "o" ? "bg-casper" : "hover:bg-casper/5"} grid cursor-pointer justify-items-center rounded-md p-[calc(--spacing(2.5)+1px)] duration-200`}
         >
           <IconO
-            className={`${playerMark === "O" ? "fill-mirage" : "fill-casper"} duration-200`}
+            className={`${playerMark === "o" ? "fill-mirage" : "fill-casper"} duration-200`}
           />
         </label>
         <input
           type="radio"
           name="playerMark"
-          id="O"
+          id="o"
           className="sr-only"
-          value="O"
-          checked={playerMark === "O"}
-          onChange={() => setplayerMark("O")}
+          value="o"
+          checked={playerMark === "o"}
+          onChange={() => setplayerMark("o")}
         />
       </div>
       <span className="leading-[normal] font-medium tracking-wider uppercase">
-        Remember : X Goes First
+        Remember : x Goes First
       </span>
     </div>
   );


### PR DESCRIPTION
This PR replaces useState with useGameContext in the PickPlayer component and ensures player values are always lowercase ('x' and 'o') for consistency with the game context.