### PR TITLE
Refactor: Replace mode values in GameContext (solo | multiplayer)

### DIFF
--- a/src/contexts/GameContext/GameContext.tsx
+++ b/src/contexts/GameContext/GameContext.tsx
@@ -2,9 +2,9 @@ import { createContext } from "react";
 
 type GameContextProps = {
   playerMark: "x" | "o";
-  mode: "cpu" | "player";
+  mode: "solo" | "multiplayer";
   setPlayerMark: (mark: "x" | "o") => void;
-  setMode: (mode: "cpu" | "player") => void;
+  setMode: (mode: "solo" | "multiplayer") => void;
 };
 
 export const GameContext = createContext<GameContextProps | null>(null);

--- a/src/contexts/GameContext/GameContextProvider.tsx
+++ b/src/contexts/GameContext/GameContextProvider.tsx
@@ -5,7 +5,7 @@ import { useLocalStorage } from "../../hooks/useLocalStorage";
 // prettier-ignore
 export function GameContextProvider({ children }: { children: React.ReactNode }) {
   const [playerMark, setPlayerMark] = useLocalStorage<"x" | "o">("playerMark", "x");
-  const [mode, setMode] = useLocalStorage<"cpu" | "player">("mode", "cpu");
+  const [mode, setMode] = useLocalStorage<"solo" | "multiplayer">("mode", "solo");
 
   return (
     <GameContext.Provider value={{ playerMark, mode, setPlayerMark, setMode }}>


### PR DESCRIPTION
This PR just replaces the mode values ​​in GameContext to "solo" and "multiplayer" for consistency.