### PR TITLE
Chore: Add tailwind-merge and update TailwindCSS to v4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.4.0",
+        "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.0.16"
       },
       "devDependencies": {
@@ -4014,6 +4015,16 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
+      "integrity": "sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.0.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.4.0",
-        "tailwind-merge": "^3.2.0",
-        "tailwindcss": "^4.0.16"
+        "tailwind-merge": "^3.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -27,6 +26,7 @@
         "globals": "^15.15.0",
         "prettier": "^3.5.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
+        "tailwindcss": "^4.1.5",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.24.1",
         "vite": "^6.2.0",
@@ -1569,6 +1569,12 @@
         "tailwindcss": "4.0.16"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.16.tgz",
+      "integrity": "sha512-i/SbG7ThTIcLshcFJL+je7hCv9dPis4Xl4XNeel6iZNX42pp/BZ+la+SbZIPoYE+PN8zhKbnHblpQ/lhOWwIeQ==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.16.tgz",
@@ -1781,6 +1787,12 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6"
       }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.16.tgz",
+      "integrity": "sha512-i/SbG7ThTIcLshcFJL+je7hCv9dPis4Xl4XNeel6iZNX42pp/BZ+la+SbZIPoYE+PN8zhKbnHblpQ/lhOWwIeQ==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4027,9 +4039,10 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.16.tgz",
-      "integrity": "sha512-i/SbG7ThTIcLshcFJL+je7hCv9dPis4Xl4XNeel6iZNX42pp/BZ+la+SbZIPoYE+PN8zhKbnHblpQ/lhOWwIeQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.5.tgz",
+      "integrity": "sha512-nYtSPfWGDiWgCkwQG/m+aX83XCwf62sBgg3bIlNiiOcggnS1x3uVRDAuyelBFL+vJdOPPCGElxv9DjHJjRHiVA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.4.0",
+    "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.0.16"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.4.0",
-    "tailwind-merge": "^3.2.0",
-    "tailwindcss": "^4.0.16"
+    "tailwind-merge": "^3.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
@@ -30,6 +29,7 @@
     "globals": "^15.15.0",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
+    "tailwindcss": "^4.1.5",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0",


### PR DESCRIPTION
This PR adds the tailwind-merge dependency to support the creation of the cn utility function, which helps manage TailwindCSS class names. It also updates the tailwindcss dependency to version 4.1 and moves it to devDependencies.