### PR TITLE
fix(hooks/useGameLogic): correctly access move status and board

### DIFF
--- a/src/hooks/game/useGameLogic.ts
+++ b/src/hooks/game/useGameLogic.ts
@@ -34,13 +34,13 @@ function useGameLogic() {
   function handleMakeMove(row: number, column: number) {
     if (!isGameActive) return;
 
-    const updatedBoard = makeMove(board, row, column, turn);
-    if (!updatedBoard) return;
+    const move = makeMove(board, row, column, turn);
+    if (move.status === "invalid") return;
 
-    const hasWinner = checkWinner(updatedBoard);
-    const isDraw = !hasWinner && !checkMovesLeft(updatedBoard);
+    const hasWinner = checkWinner(move.board);
+    const isDraw = !hasWinner && !checkMovesLeft(move.board);
 
-    setBoard(updatedBoard);
+    setBoard(move.board);
 
     if (!hasWinner && !isDraw) {
       setTurn(turn === "x" ? "o" : "x");


### PR DESCRIPTION
This PR fixes move handling in the game logic by properly accessing the status and board returned from the `makeMove` utility.